### PR TITLE
Remove the flutter dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,15 +8,9 @@ dependencies:
     pointycastle: ^3.1.3
     base58check: ^2.0.0
     convert: ^3.0.0
-    flutter:
-        sdk: flutter
 
 dev_dependencies:
     test: ^1.17.9
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
-
-flutter:
-


### PR DESCRIPTION
This package doesn't actually use flutter in any meaningful way and the dependency prevents it from being used in plain dart.